### PR TITLE
Cancel superseded GitHub workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-images:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This serves two purposes:

- cuts costs by canceling CI when pull requests are updated
- prevents issues when releasing after pull requests are merged

Elaborating on that second point, two pull requests are merged, so two release-image workflows are started as a result. The earlier one takes longer to run, however, and mutates the 'latest' tag last. This is a great example of the dangers of mutability.